### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# This code has been sampled from the following source:
+# https://gist.github.com/FullStackForger/20bbf62861394b1a3de0
+#
+# The reason for this is to ensure a lot of misc. files do not spam this repository upon
+# being linked to a unity project
+
+###
+# Unity folders and files
+###
+[Aa]ssets/AssetStoreTools*
+[Bb]uild/
+[Ll]ibrary/
+[Ll]ocal[Cc]ache/
+[Oo]bj/
+[Tt]emp/
+[Uu]nityGenerated/
+# file on crash reports
+sysinfo.txt
+# Unity3D generated meta files
+*.pidb.meta
+
+###
+# VS/MD solution and project files
+###
+[Ee]xportedObj/
+*.booproj
+*.csproj
+*.sln
+*.suo
+*.svd
+*.unityproj
+*.user
+*.userprefs
+*.pidb
+.DS_Store
+
+###
+# OS generated
+###
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
This code has been sampled from the following source:
[GitHub Link](https://gist.github.com/FullStackForger/20bbf62861394b1a3de0)

The reason for this is to ensure a lot of misc. files do not spam this repository upon being linked to a unity project.